### PR TITLE
Use setuptools infrastructure for testing; show 'install dictorm[postgresql]'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - "3.4"
     - "3.5"
 install:
-    - "pip install -e ."
+    - "pip install -e .[postgresql]"
 before_script:
     - psql -c 'create database dictorm;' -U postgres
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ python:
     - "3.4"
     - "3.5"
 install:
-    - "pip install -r requirements.testing.txt"
+    - "pip install -e ."
 before_script:
     - psql -c 'create database dictorm;' -U postgres
 script:
     # Run tests verbosely
-    - "green -vv --run-coverage dictorm"
+    - "python setup.py test"
     # Test installation
     - "python setup.py install"
     #  Verify that dictorm can be imported

--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ you to select/insert/update/delete rows of a database as if they were Python
 Dictionaries.
 
 ## Installation
-Install dictorm using pip:
+Install dictorm using `pip`, with the default sqlite backend:
 ```bash
 pip install dictorm
+```
+
+Install with the Postgres backend:
+```bash
+pip install dictorm[Postgresql]
 ```
 
 ## Quick & Simple Example!
@@ -432,9 +437,7 @@ bob['manager_id'] = None
 # Testing
 ```bash
 # Get postgres container
-docker run --name dictorm -e POSTGRES_PASSWORD=dictorm -p 54321:5432 -d postgres:9.6
-# Install test requirements
-pip install -r requirements.testing.txt
-# Run the tests
-green -vv
+sudo docker run --name dictorm -e POSTGRES_PASSWORD=dictorm -p 54321:5432 -d postgres:9.6
+# Install test requirements & run:
+python setup.py test
 ```

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -1,4 +1,0 @@
-coverage
-coveralls
-green
-psycopg2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test = green

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,16 @@ config = {
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",
         ],
-    'test_suite':'dictorm.test_dictorm',
+    'test_suite': 'dictorm.test',
+    'setup_requires': ['green'],
+    'tests_require': [
+        'coverage',
+        'coveralls',
+        'green',
+        'psycopg2',
+    ],
     'extras_require':{
         'Postgresql': ['psycopg2'],
-        'Testing': testing_requirements,
         }
     }
 

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,6 @@
 from setuptools import setup
 from dictorm.dictorm import __version__, __doc__ as ddoc
 
-with open('requirements.testing.txt', 'r') as fh:
-    testing_requirements = fh.read().splitlines()
-
 config = {
     'name':'dictorm',
     'version':str(__version__),

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ config = {
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",
         ],
-    'test_suite': 'dictorm.test',
     'setup_requires': ['green'],
     'tests_require': [
         'coverage',


### PR DESCRIPTION
Add 'green' as alias for 'test' (see https://github.com/CleanCut/green#setuppy-command).

With this PR I'm trying to get the most out of what setuptools gives us: 

- make plain `python setup.py test` work (install  `tests_require`, run tests);
- use the syntax for installing extras (`dictorm[postgresql]`).